### PR TITLE
Update URLs for licenses

### DIFF
--- a/development.html
+++ b/development.html
@@ -45,10 +45,10 @@ title: Development
 		<header>
 			<h3 title="License">授權宣告</h3>
 		</header>
-		<p>libchewing is licensed under the terms of the <a href="http://www.fsf.org/copyleft/lgpl.html">GNU Library General Public License</a>.</p>
-		<p>ibus-chewing is licensed under the terms of the <a href="http://www.fsf.org/copyleft/gpl.html">GNU General Public License</a>.</p>
-		<p>fcitx5-chewing is license under the terms of the <a href="http://www.fsf.org/copyleft/gpl.html">GNU Library General Public License</a>. (same as Fcitx 5)</p>
-		<p>windows-chewing-tsf is license under the terms of the <a href="http://www.fsf.org/copyleft/lgpl.html">GNU Library General Public License</a>.</p>
+		<p>libchewing is licensed under the terms of the <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html">GNU Lesser General Public License, version 2.1</a>.</p>
+		<p>ibus-chewing is licensed under the terms of the <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html">GNU General Public License, version 2</a>.</p>
+		<p>fcitx5-chewing is license under the terms of the <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html">GNU Lesser General Public License, version 2.1</a>. (same as Fcitx 5)</p>
+		<p>windows-chewing-tsf is license under the terms of the <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html">GNU Lesser General Public License, version 2.1</a>.</p>
 	</section>
 	<section>
 		<header>


### PR DESCRIPTION
The licenses are verified/taken from each repo.

Here it states "GNU Library General Public License" however the repos actually use "GNU Lesser General Public License".